### PR TITLE
Add cortex-m targets to docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,19 @@ version = "0.2.0"
 
 [dependencies]
 vcell = "0.1.0"
+
+[package.metadata.docs.rs]
+targets = [
+	"x86_64-unknown-linux-gnu",
+	"x86_64-apple-darwin",
+	"x86_64-pc-windows-msvc",
+	"i686-unknown-linux-gnu",
+	"i686-pc-windows-msvc",
+	"thumbv8m.main-none-eabihf",
+    "thumbv6m-none-eabi",
+    "thumbv7em-none-eabi",
+    "thumbv7em-none-eabihf",
+    "thumbv7m-none-eabi",
+    "thumbv8m.base-none-eabi",
+    "thumbv8m.main-none-eabi",
+]


### PR DESCRIPTION
Since rust-embedded/cortex-m#256 (released in v0.7) the docs links from cortex-m to this crate link to the target specific version. As these targets are not included on this crate the links fail.

For example; see the links to RO on this page https://docs.rs/cortex-m/0.7.3/cortex_m/peripheral/cpuid/struct.RegisterBlock.html